### PR TITLE
Remove teardown calls in kube-down

### DIFF
--- a/cluster/kube-down.sh
+++ b/cluster/kube-down.sh
@@ -27,9 +27,6 @@ source "${KUBE_ROOT}/cluster/${KUBERNETES_PROVIDER}/util.sh"
 echo "Bringing down cluster using provider: $KUBERNETES_PROVIDER"
 
 verify-prereqs
-teardown-monitoring-firewall
-teardown-logging-firewall
-
 kube-down
 
 echo "Done"


### PR DESCRIPTION
Right now, these simply echo out TODO because the functions haven't been 
completed in the relevant util.sh (depending on your cloud provider, so 
Vagrant users use cluster/vagrant/util.sh where the functions are called 
from).

TODO is messy, and whilst I appreciate that Kubernetes is a WiP, it was rather
confusing seeing only the word TODO printed to stdout during kube-down.sh
whilst new to Kubernetes.

I appreciate that the better solution for this is to have teardowns
implemented, but hopefully this will be a quick win in the meantime.